### PR TITLE
fix: improve typescript compilation

### DIFF
--- a/packages/custom-elements-json-analyzer/README.md
+++ b/packages/custom-elements-json-analyzer/README.md
@@ -12,6 +12,12 @@ This implementation is at a very early stage of development, and there will prob
 npm i -D @custom-elements-manifest/analyzer
 ```
 
+This library has `peerDependencies` listings for `typescript^4.0.0`.
+
+```bash
+npm i -D typescript
+```
+
 ## Usage
 
 ```bash
@@ -359,6 +365,7 @@ export default {
   exclude: ['!src/foo.js'], // prefix with a `!` to exclude
   dev: true,
   tsTarget: 2, // sets the tsTarget for typescript
+  tsConfigName: 'tsconfig.json', // sets the name of the typescript configuration file to use.
 
   /* Use if you want to analyze a string of code, for example for the playground API. Both are required in this case */
   path: '',
@@ -376,6 +383,7 @@ interface userConfigOptions {
   exclude: string[],
   dev: boolean,
   tsTarget: number,
+  tsConfigName: string,
 
   /* Use if you want to analyze a string of code, for example for the playground API. Both are required in this case */
   path: string,
@@ -419,8 +427,8 @@ export default {
   plugins: [
     function myPlugin() {
       return {
-        // Runs for each module
-        analyzePhase({node, moduleDoc}){
+        // Runs for each module (`program`/`typeChecker` not available if analyzing string of code)
+        analyzePhase({node, moduleDoc, program, typeChecker}){ 
           // You can use this phase to access a module's AST nodes and mutate the custom-elements-manifest
           switch (node.kind) {
             case ts.SyntaxKind.ClassDeclaration:

--- a/packages/custom-elements-json-analyzer/package.json
+++ b/packages/custom-elements-json-analyzer/package.json
@@ -3,10 +3,6 @@
   "version": "0.1.8",
   "description": "",
   "license": "MIT",
-  "bin": {
-    "custom-elements-manifest": "./dist/index.js",
-    "cem": "./dist/index.js"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/open-wc/custom-elements-manifest.git"
@@ -17,6 +13,10 @@
     "url": "https://github.com/open-wc/custom-elements-manifest"
   },
   "main": "dist/index.js",
+  "bin": {
+    "custom-elements-manifest": "./dist/index.js",
+    "cem": "./dist/index.js"
+  },
   "module": "index.mjs",
   "scripts": {
     "build": "tsc",
@@ -28,6 +28,13 @@
     "tsc:watch": "tsc --watch",
     "update-fixtures": "node scripts/update-version.mjs --version 0.1.0"
   },
+  "files": [
+    "*.d.ts",
+    "*.js",
+    "*.mjs",
+    "dist",
+    "plugins"
+  ],
   "keywords": [
     "custom-elements",
     "custom-elements-json",
@@ -37,13 +44,15 @@
     "customelementsjson",
     "customelementsmanifest"
   ],
+  "peerDependencies": {
+    "typescript": "^4.0.0"
+  },
   "dependencies": {
     "@custom-elements-manifest/helpers": "^0.0.3",
     "@web/config-loader": "^0.1.3",
     "command-line-args": "^5.1.1",
     "comment-parser": "^0.7.6",
-    "globby": "^11.0.1",
-    "typescript": "~4.0.0"
+    "globby": "^11.0.1"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",
@@ -59,11 +68,13 @@
     "nodemon": "^2.0.4",
     "prettier": "^2.1.2",
     "prettier-plugin-package": "^1.0.0",
-    "ts-node": "^9.0.0"
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.0"
   },
   "contributors": [
     "Pascal Schilp <pascalschilp@gmail.com>"
   ],
+  "customElementsManifest": "custom-elements.json",
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
     "plugins": [
@@ -89,18 +100,10 @@
       "@typescript-eslint/no-var-requires": "off"
     }
   },
-  "files": [
-    "*.d.ts",
-    "*.js",
-    "*.mjs",
-    "dist",
-    "plugins"
-  ],
   "prettier": {
     "singleQuote": true,
     "arrowParens": "avoid",
     "printWidth": 100,
     "trailingComma": "all"
-  },
-  "customElementsManifest": "custom-elements.json"
+  }
 }

--- a/packages/custom-elements-json-analyzer/src/utils/compiler.ts
+++ b/packages/custom-elements-json-analyzer/src/utils/compiler.ts
@@ -1,0 +1,54 @@
+import ts, { CompilerOptions, ModuleKind, ModuleResolutionKind, ScriptTarget } from 'typescript';
+
+/**
+ * The most general and safe version of the TypeScript compiler options.
+ */
+const defaultCompilerOptions: CompilerOptions = {
+  noEmitOnError: false,
+  allowJs: true,
+  experimentalDecorators: true,
+  target: ScriptTarget.Latest,
+  downlevelIteration: true,
+  module: ModuleKind.ESNext,
+  strictNullChecks: true,
+  moduleResolution: ModuleResolutionKind.NodeJs,
+  esModuleInterop: true,
+  noEmit: true,
+  pretty: true,
+  allowSyntheticDefaultImports: true,
+  allowUnreachableCode: true,
+  allowUnusedLabels: true,
+  skipLibCheck: true,
+};
+
+/**
+ * Attempst to find, parse and return the TypeScript configuration file (`tsconfig.json`). If it
+ * can't be found this function will return `undefined`.
+ */
+export function readTypeScriptConfigFile(configName?: string): CompilerOptions | undefined {
+  const configPath = ts.findConfigFile(
+    process.cwd(),
+    ts.sys.fileExists,
+    configName ?? 'tsconfig.json',
+  );
+
+  if (!configPath) return undefined;
+
+  return ts.readConfigFile(configPath!, ts.sys.readFile).config;
+}
+
+/**
+ * Create a new 'Program' instance. A Program is an immutable collection of 'SourceFile's and a
+ * 'CompilerOptions' that represent a compilation unit.
+ *
+ * Creating a program proceeds from a set of root files, expanding the set of inputs by following
+ * imports and triple-slash-reference-path directives transitively. '@types' and
+ * triple-slash-reference-types are also pulled in.
+ *
+ * @param rootNames - A set of root files.
+ * @param configName - The name of the `tsconfig.json` file.
+ */
+export function createTypeScriptProgram(rootFiles: string[], configName?: string) {
+  const config = configName ? readTypeScriptConfigFile(configName) : defaultCompilerOptions;
+  return ts.createProgram(rootFiles, config ?? defaultCompilerOptions);
+}

--- a/packages/custom-elements-json-analyzer/test/integration.test.js
+++ b/packages/custom-elements-json-analyzer/test/integration.test.js
@@ -31,7 +31,9 @@ describe('integration tests', () => {
       const outputPath = path.join(fixturesDir, `${testCase}/output.json`);
 
       let modulePaths = await globby(packagePath);
-      modulePaths = modulePaths.filter(path => !path.includes('custom-elements-manifest.config.js'))
+      modulePaths = modulePaths.filter(
+        path => !path.includes('custom-elements-manifest.config.js'),
+      );
 
       let plugins = [];
       try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2940,11 +2940,6 @@ typescript@^4.0.0, typescript@^4.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
   integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
-typescript@~4.0.0:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
-
 typical@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"


### PR DESCRIPTION
**Package:** `@custom-elements-manifest/analyzer`

This PR fixes issue #57 and introduces a few improvements to the TypeScript compilation process.

**Changes**

Important to note ahead of the time that there are more changes in the git history than intended because simply saving some files caused prettier/eslint to reformat them. Main changes were simply inside the start of the `create` function inside `create.ts` and the new `utils/compiler.ts` file.

- Moved `typescript` to `peerDependencies` to avoid version mismatch (see #57).
- Use `createProgram` to compile instead of `createSourceFile` to add type checking. It'll fallback to using `createSourceFile` when `path` and `sourceCode` config option is present.
- Add `tsConfigName` option to cem configuration file to enable users to specify a TS config file to use when compiling. If the option is not present it'll default to a sensible configuration file.
- Pass `program` and `typeChecker` to plugins to enable deeper AST analysis or the ability to extract symbol/type information.
- Updated `README.md` documentation with changes.

All tests are passing ✅ 